### PR TITLE
Update server handler from get to post

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ### Changed
 - update pr template #4) 
+- update server handler from get to post (#6)
 
 ### Fixed
 - 

--- a/DEVLOG.md
+++ b/DEVLOG.md
@@ -6,6 +6,45 @@ Go.
 
 ---
 
+# Development Log: Go Job Queue
+This is an ongoing technical journal documenting my progress, design decisions,
+experiments, and reflections while building an HTTP-based job queue system in
+Go.
+
+---
+
+## 📅 [2025-05-22]
+
+### What I worked on:
+- Implemented JSON marshaling/unmarshaling with structs for HTTP request handling
+- Learned about Go's package organization and struct visibility rules
+- Explored dependency injection patterns vs global state for logging
+- Debugged issues with Go test caching affecting integration tests
+- Set up HTTP handler for processing JSON POST requests
+
+### Problems or blockers:
+- Initially struggled with nil pointer dereference when trying to use logger as global variable before initialization
+- Encountered confusion with Go test caching making it appear that server wasn't receiving requests
+
+### Decisions made and why:
+- **Struct Organization**: Decided to keep related structs in the same package rather than separate files, following Go's "organize by functionality, not by type" principle
+- **Global Logger Access**: Chose to stick with global state for logging (controlled global) rather than full dependency injection, balancing convenience vs testability for infrastructure concerns like logging
+- **JSON Handling**: Used Go's built-in `encoding/json` package with struct tags for clean serialization/deserialization
+- **Testing Approach**: Learned to use `go test -count=1` or `go clean -testcache` to handle integration test caching issues
+
+### What I learned:
+- **Go Package System**: Files in the same package can access each other's exported types without imports, but both files must have identical package declarations. You cannot export structs from a test file.
+- **io.Reader Interface**: How to convert marshaled JSON byte slices to `io.Reader` using `bytes.NewBuffer()` for HTTP requests
+- **Dependency Injection Trade-offs**: Understood the tension between explicit dependencies (testable but verbose) vs global state (convenient but harder to test)
+- **Go Test Caching**: How Go aggressively caches test results and why this can be confusing for integration tests that depend on external services
+
+### Next steps:
+- Expand on struct learning to include JSON tags
+- Begin speccing out the struct for our job que messages that our server will
+receive.
+
+---
+
 ## 📅 [2025-05-18]
 
 ### What I worked on:
@@ -39,6 +78,8 @@ importance of early failure in observability-critical subsystems like logging
 
 ### Next steps:
 - Learn how to interact with my http server via my go application
+
+---
 
 ## 📅 [2025-05-17]
 

--- a/server/server.go
+++ b/server/server.go
@@ -4,10 +4,18 @@
 package server
 
 import (
+	"encoding/json"
 	"fmt"
 	"http-job-que-system/logger"
 	"net/http"
 )
+
+type Message struct {
+	Id   int
+	Name string
+	Body string
+	Time int64
+}
 
 // Start launches the HTTP server on port 8080.
 // It logs a startup message using the global logger and begins listening
@@ -16,14 +24,26 @@ import (
 //
 // This function should be called only after the logger has been initialized.
 func Start() {
-	var log = logger.Log
 	startupMsg := "Server listening on port 8080"
 
-	log.Println(startupMsg)
+	logger.Log.Println(startupMsg)
 	fmt.Println(startupMsg)
+
+	http.HandleFunc("/foo", fooHandler)
 
 	err := http.ListenAndServe(":8080", nil)
 	if err != nil {
-		log.Fatal("Server failed to start:", err)
+		logger.Log.Fatal("Server failed to start:", err)
 	}
+}
+
+func fooHandler(w http.ResponseWriter, r *http.Request) {
+	var m Message
+	dec := json.NewDecoder(r.Body)
+	err := dec.Decode(&m)
+	if err != nil {
+		fmt.Println("Decode error:", err) // Add this before Fatal
+		logger.Log.Fatal("Error decoding request body json")
+	}
+	fmt.Println("Message:", m)
 }

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -1,0 +1,35 @@
+package server
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"testing"
+)
+
+func TestFooHandler(t *testing.T) {
+
+	// Why when we declare our json body outside the loop do we only get 1 post
+	// response body
+
+	for i := range 10 {
+		m := Message{i, "Alice", "Hello", 1294706395881547000}
+		b, err := json.Marshal(m)
+		if err != nil {
+			t.Fatalf("Failed to marshal JSON")
+		}
+
+		buf := bytes.NewBuffer(b)
+
+		resp, err := http.Post("http://localhost:8080/foo", "application/json", buf)
+		if err != nil {
+			t.Fatalf("Request failed: %v", err)
+		}
+
+		if resp.StatusCode != http.StatusOK {
+			t.Errorf("Unexpected status: %d", resp.StatusCode)
+		}
+
+		resp.Body.Close()
+	}
+}


### PR DESCRIPTION
## 📝 Summary
Implement HTTP JSON handler with proper Go package organization. Add testing setup and fix test caching problems for reliable integration testing.

## 🔧 Changes
- Add `Message` struct with JSON marshaling/unmarshaling support
- Implement `/foo` HTTP handler for processing JSON POST requests  
- Add integration tests with proper HTTP client setup using `bytes.NewBuffer()`
- Resolve Go test caching issues for reliable test execution

## 🎯 Rationale
This change establishes the foundation for JSON-based communication with the job queue server. The HTTP handler will serve as the entry point for job submissions, and proper package organization ensures maintainable code structure as the system grows.

## ✅ Checklist
- [x] Code compiles without errors
- [x] Manually tested where relevant
- [x] Changelog updated
- [x] Devlog updated

## 📚 Notes (Optional)
- Future consideration: May want to add JSON struct tags for better field control as the Message schema evolves
- Test caching can be bypassed with `go test -count=1` for integration tests that depend on external services
- Global logger pattern chosen for convenience; consider dependency injection if testing becomes complex